### PR TITLE
Added LED_BUILTIN & SS/MOSI/MISO/SCK

### DIFF
--- a/variants/m5stack_timer_cam/pins_arduino.h
+++ b/variants/m5stack_timer_cam/pins_arduino.h
@@ -11,11 +11,19 @@
 #define digitalPinToInterrupt(p)    (((p)<40)?(p):-1)
 #define digitalPinHasPWM(p)         (p < 34)
 
+static const uint8_t LED_BUILTIN = 2;
+#define BUILTIN_LED  LED_BUILTIN // backward compatibility
+
 static const uint8_t TX = 1;
 static const uint8_t RX = 3;
 
 static const uint8_t SDA = 4;
 static const uint8_t SCL = 13;
+
+static const uint8_t SS   = 5;
+static const uint8_t MOSI = 23;
+static const uint8_t MISO = 19;
+static const uint8_t SCK  = 18;
 
 static const uint8_t G23 = 23;
 static const uint8_t G25 = 25;


### PR DESCRIPTION
- A LED is available on the PCB, so LED_BUILTIN needs to be defined
- SS/MOSI/MISO/SCK are available on the ESP32 chip. Also some libraries need it to compile (e.g. U8g2)